### PR TITLE
DOC: Change extract-text.md example codes from using cm to tm

### DIFF
--- a/docs/user/extract-text.md
+++ b/docs/user/extract-text.md
@@ -118,7 +118,7 @@ def visitor_svg_rect(op, args, cm, tm):
         dwg.add(dwg.rect((x, y), (w, h), stroke="red", fill_opacity=0.05))
 
 
-def visitor_svg_text(text, cm, tm, fontDict, fontSize):
+def visitor_svg_text(text, cm, tm, font_dict, font_size):
     (x, y) = (tm[4], tm[5])
     dwg.add(dwg.text(text, insert=(x, y), fill="blue"))
 

--- a/docs/user/extract-text.md
+++ b/docs/user/extract-text.md
@@ -84,7 +84,7 @@ parts = []
 
 
 def visitor_body(text, cm, tm, font_dict, font_size):
-    y = cm[5]
+    y = tm[5]
     if y > 50 and y < 720:
         parts.append(text)
 
@@ -119,7 +119,7 @@ def visitor_svg_rect(op, args, cm, tm):
 
 
 def visitor_svg_text(text, cm, tm, fontDict, fontSize):
-    (x, y) = (cm[4], cm[5])
+    (x, y) = (tm[4], tm[5])
     dwg.add(dwg.text(text, insert=(x, y), fill="blue"))
 
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2432](https://togithub.com/py-pdf/pypdf/pull/2432).



The original branch is fork-2432-etern4l-white/docs-extract-text