### PR TITLE
ROB: discard /I in choice fields for compatibility with acrobat

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -987,6 +987,11 @@ class PdfWriter(PdfDocCommon):
                     or writer_parent_annot.get("/T", None) == field
                 ):
                     continue
+                if (
+                    writer_parent_annot.get("/FT", None) == "/Ch"
+                    and "/I" in writer_parent_annot
+                ):
+                    del writer_parent_annot["/I"]
                 if flags:
                     writer_annot[NameObject(FA.Ff)] = NumberObject(flags)
                 if isinstance(value, list):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2217,3 +2217,16 @@ def test_init_without_named_arg():
     assert len(writer._objects) == nb
     writer = PdfWriter(by)
     assert len(writer._objects) == nb
+
+
+@pytest.mark.enable_socket()
+def test_i_in_choice_fields():
+    """Cf #2611"""
+    url = "https://github.com/py-pdf/pypdf/files/15176321/FRA.F.6180.150.pdf"
+    name = "iss2611.pdf"
+    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    assert "/I" in writer.get_fields()["State"].indirect_reference.get_object()
+    writer.update_page_form_field_values(
+        writer.pages[0], {"State": "NY"}, auto_regenerate=False
+    )
+    assert "/I" not in writer.get_fields()["State"].indirect_reference.get_object()


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2614](https://togithub.com/py-pdf/pypdf/pull/2614).



The original branch is fork-2614-pubpub-zz/iss2611