### PR TITLE
ROB: cope with missing Standard 14 fonts in fields

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -53,7 +53,7 @@ from typing import (
     cast,
 )
 
-from ._cmap import build_char_map_from_dict
+from ._cmap import _default_fonts_space_width, build_char_map_from_dict
 from ._doc_common import PdfDocCommon
 from ._encryption import EncryptAlgorithm, Encryption
 from ._page import PageObject
@@ -835,7 +835,8 @@ class PdfWriter(PdfDocCommon):
             ).get_object(),
         )
         dr = dr.get("/Font", DictionaryObject()).get_object()
-        if font_name not in dr:
+        # _default_fonts_space_width keys is the list of Standard fonts
+        if font_name not in dr and font_name not in _default_fonts_space_width:
             # ...or AcroForm dictionary
             dr = cast(
                 Dict[Any, Any],

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2253,3 +2253,19 @@ def test_selfont():
     assert (
         b"Text_2" in writer.pages[0]["/Annots"][2].get_object()["/AP"]["/N"].get_data()
     )
+
+
+@pytest.mark.enable_socket()
+def test_no_ressource_for_14_std_fonts(caplog):
+    """Cf #2670"""
+    url = "https://github.com/py-pdf/pypdf/files/15405390/f1040.pdf"
+    name = "iss2670.pdf"
+    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    p = writer.pages[0]
+    for a in p["/Annots"]:
+        a = a.get_object()
+        if a["/FT"] == "/Tx":
+            writer.update_page_form_field_values(
+                p, {a["/T"]: "Brooks"}, auto_regenerate=False
+            )
+    assert "Font dictionary for /Helvetica not found." in caplog.text


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2677](https://togithub.com/py-pdf/pypdf/pull/2677).



The original branch is fork-2677-pubpub-zz/iss2670