### PR TITLE
BUG: Fix deprecation for Ressources when using old constants

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -507,6 +507,57 @@ def _human_readable_bytes(bytes: int) -> str:
         return f"{bytes / 10**9:.1f} GB"
 
 
+# The following class has been copied from Django:
+# https://github.com/django/django/blob/adae619426b6f50046b3daaa744db52989c9d6db/django/utils/functional.py#L51-L65
+#
+# Original license:
+#
+# ---------------------------------------------------------------------------------
+# Copyright (c) Django Software Foundation and individual contributors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of Django nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ---------------------------------------------------------------------------------
+class classproperty:  # noqa: N801
+    """
+    Decorator that converts a method with a single cls argument into a property
+    that can be accessed directly from the class.
+    """
+
+    def __init__(self, method=None):  # type: ignore  # noqa: ANN001
+        self.fget = method
+
+    def __get__(self, instance, cls=None) -> Any:  # type: ignore  # noqa: ANN001
+        return self.fget(cls)
+
+    def getter(self, method):  # type: ignore  # noqa: ANN001, ANN202
+        self.fget = method
+        return self
+
+
 @dataclass
 class File:
     from .generic import IndirectObject
@@ -630,54 +681,3 @@ class Version:
                 return False
 
         return len(self.components) < len(other.components)
-
-
-# The following class has been copied from Django:
-# https://github.com/django/django/blob/adae619426b6f50046b3daaa744db52989c9d6db/django/utils/functional.py#L51-L65
-#
-# Original license:
-#
-# ---------------------------------------------------------------------------------
-# Copyright (c) Django Software Foundation and individual contributors.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-#
-#     1. Redistributions of source code must retain the above copyright notice,
-#        this list of conditions and the following disclaimer.
-#
-#     2. Redistributions in binary form must reproduce the above copyright
-#        notice, this list of conditions and the following disclaimer in the
-#        documentation and/or other materials provided with the distribution.
-#
-#     3. Neither the name of Django nor the names of its contributors may be used
-#        to endorse or promote products derived from this software without
-#        specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# ---------------------------------------------------------------------------------
-class classproperty:  # noqa: N801
-    """
-    Decorator that converts a method with a single cls argument into a property
-    that can be accessed directly from the class.
-    """
-
-    def __init__(self, method=None):  # type: ignore  # noqa: ANN001
-        self.fget = method
-
-    def __get__(self, instance, cls=None) -> Any:  # type: ignore  # noqa: ANN001
-        return self.fget(cls)
-
-    def getter(self, method):  # type: ignore  # noqa: ANN001, ANN202
-        self.fget = method
-        return self

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -672,12 +672,12 @@ class classproperty:  # noqa: N801
     that can be accessed directly from the class.
     """
 
-    def __init__(self, method=None):  # noqa: ANN001
+    def __init__(self, method=None):  # noqa: ANN001  # type: ignore[no-untyped-def]
         self.fget = method
 
-    def __get__(self, instance, cls=None) -> Any:  # noqa: ANN001
+    def __get__(self, instance, cls=None) -> Any:  # noqa: ANN001  # type: ignore[no-untyped-def]
         return self.fget(cls)
 
-    def getter(self, method):  # noqa: ANN001, ANN202
+    def getter(self, method):  # noqa: ANN001, ANN202  # type: ignore[no-untyped-def]
         self.fget = method
         return self

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -666,18 +666,18 @@ class Version:
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ---------------------------------------------------------------------------------
-class classproperty:
+class classproperty:  # noqa: N801
     """
     Decorator that converts a method with a single cls argument into a property
     that can be accessed directly from the class.
     """
 
-    def __init__(self, method=None):
+    def __init__(self, method=None):  # noqa: ANN001
         self.fget = method
 
-    def __get__(self, instance, cls=None):
+    def __get__(self, instance, cls=None) -> Any:  # noqa: ANN001
         return self.fget(cls)
 
-    def getter(self, method):
+    def getter(self, method):  # noqa: ANN001, ANN202
         self.fget = method
         return self

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -672,12 +672,12 @@ class classproperty:  # noqa: N801
     that can be accessed directly from the class.
     """
 
-    def __init__(self, method=None):  # noqa: ANN001  # type: ignore[no-untyped-def]
+    def __init__(self, method=None):  # type: ignore  # noqa: ANN001
         self.fget = method
 
-    def __get__(self, instance, cls=None) -> Any:  # noqa: ANN001  # type: ignore[no-untyped-def]
+    def __get__(self, instance, cls=None) -> Any:  # type: ignore  # noqa: ANN001
         return self.fget(cls)
 
-    def getter(self, method):  # noqa: ANN001, ANN202  # type: ignore[no-untyped-def]
+    def getter(self, method):  # type: ignore  # noqa: ANN001, ANN202
         self.fget = method
         return self

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -630,3 +630,54 @@ class Version:
                 return False
 
         return len(self.components) < len(other.components)
+
+
+# The following class has been copied from Django:
+# https://github.com/django/django/blob/adae619426b6f50046b3daaa744db52989c9d6db/django/utils/functional.py#L51-L65
+#
+# Original license:
+#
+# ---------------------------------------------------------------------------------
+# Copyright (c) Django Software Foundation and individual contributors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of Django nor the names of its contributors may be used
+#        to endorse or promote products derived from this software without
+#        specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ---------------------------------------------------------------------------------
+class classproperty:
+    """
+    Decorator that converts a method with a single cls argument into a property
+    that can be accessed directly from the class.
+    """
+
+    def __init__(self, method=None):
+        self.fget = method
+
+    def __get__(self, instance, cls=None):
+        return self.fget(cls)
+
+    def getter(self, method):
+        self.fget = method
+        return self

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -162,42 +162,42 @@ class Ressources:  # deprecated
     """
 
     @classproperty
-    def EXT_G_STATE(cls) -> str:
+    def EXT_G_STATE(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/ExtGState"  # dictionary, optional
 
     @classproperty
-    def COLOR_SPACE(cls) -> str:
+    def COLOR_SPACE(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/ColorSpace"  # dictionary, optional
 
     @classproperty
-    def PATTERN(cls) -> str:
+    def PATTERN(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Pattern"  # dictionary, optional
 
     @classproperty
-    def SHADING(cls) -> str:
+    def SHADING(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Shading"  # dictionary, optional
 
     @classproperty
-    def XOBJECT(cls) -> str:
+    def XOBJECT(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/XObject"  # dictionary, optional
 
     @classproperty
-    def FONT(cls) -> str:
+    def FONT(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Font"  # dictionary, optional
 
     @classproperty
-    def PROC_SET(cls) -> str:
+    def PROC_SET(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/ProcSet"  # array, optional
 
     @classproperty
-    def PROPERTIES(cls) -> str:
+    def PROPERTIES(cls) -> str:  # noqa: N805
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Properties"  # dictionary, optional
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -14,7 +14,7 @@ ISO 32000-2:2020 (PDF 2.0)
 from enum import IntFlag, auto
 from typing import Dict, Tuple
 
-from ._utils import deprecate_with_replacement
+from ._utils import classproperty, deprecate_with_replacement
 
 
 class Core:
@@ -161,50 +161,42 @@ class Ressources:  # deprecated
     .. deprecated:: 5.0.0
     """
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def EXT_G_STATE(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/ExtGState"  # dictionary, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def COLOR_SPACE(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/ColorSpace"  # dictionary, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def PATTERN(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Pattern"  # dictionary, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def SHADING(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Shading"  # dictionary, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def XOBJECT(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/XObject"  # dictionary, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def FONT(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Font"  # dictionary, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def PROC_SET(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/ProcSet"  # array, optional
 
-    @classmethod  # type: ignore
-    @property
+    @classproperty
     def PROPERTIES(cls) -> str:
         deprecate_with_replacement("Ressources", "Resources", "5.0.0")
         return "/Properties"  # dictionary, optional

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -437,7 +437,17 @@ def test_classproperty():
         def value2(cls) -> int:  # noqa: N805
             return 1337
 
+        @classproperty
+        def value3(cls) -> int:  # noqa: N805
+            return 1
+
+        @value3.getter
+        def value3(cls) -> int:
+            return 2
+
     assert Container.value1 == 42
     assert Container.value2 == 1337
+    assert Container.value3 == 2
     assert Container().value1 == 42
     assert Container().value2 == 1337
+    assert Container().value3 == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from pypdf._utils import (
     _get_max_pdf_version_header,
     _human_readable_bytes,
     check_if_whitespace_only,
+    classproperty,
     deprecate_with_replacement,
     deprecation_no_replacement,
     mark_location,
@@ -424,3 +425,19 @@ def test_version_compare_lt_str():
 
 def test_bad_version():
     assert Version("a").components == [(0, "a")]
+
+
+def test_classproperty():
+    class Container:
+        @classproperty
+        def value1(cls):
+            return 42
+
+        @classproperty
+        def value2(cls):
+            return 1337
+
+    assert Container.value1 == 42
+    assert Container.value2 == 1337
+    assert Container().value1 == 42
+    assert Container().value2 == 1337

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -442,7 +442,7 @@ def test_classproperty():
             return 1
 
         @value3.getter
-        def value3(cls) -> int:
+        def value3(cls) -> int:  # noqa: N805
             return 2
 
     assert Container.value1 == 42

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -430,11 +430,11 @@ def test_bad_version():
 def test_classproperty():
     class Container:
         @classproperty
-        def value1(cls):
+        def value1(cls) -> int:  # noqa: N805
             return 42
 
         @classproperty
-        def value2(cls):
+        def value2(cls) -> int:  # noqa: N805
             return 1337
 
     assert Container.value1 == 42


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2705](https://togithub.com/py-pdf/pypdf/pull/2705).



The original branch is fork-2705-stefan6419846/ressources