### PR TITLE
MAINT: Deprecate interiour_color with replacement interior_color

### DIFF
--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -258,7 +258,7 @@ class Ellipse(MarkupAnnotation):
         self,
         rect: Union[RectangleObject, Tuple[float, float, float, float]],
         *,
-        interiour_color: Optional[str] = None,
+        interior_color: Optional[str] = None,
         **kwargs: Any,
     ):
         if "interiour_color" in kwargs:

--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -210,9 +210,13 @@ class Rectangle(MarkupAnnotation):
         self,
         rect: Union[RectangleObject, Tuple[float, float, float, float]],
         *,
-        interiour_color: Optional[str] = None,
+        interior_color: Optional[str] = None,
         **kwargs: Any,
     ):
+        if "interiour_color" in kwargs:
+            deprecate_with_replacement("interiour_color", "interior_color", "6.0.0")
+            interior_color = kwargs["interiour_color"]
+            del kwargs["interiour_color"]
         super().__init__(**kwargs)
         self.update(
             {
@@ -222,9 +226,9 @@ class Rectangle(MarkupAnnotation):
             }
         )
 
-        if interiour_color:
+        if interior_color:
             self[NameObject("/IC")] = ArrayObject(
-                [FloatObject(n) for n in hex_to_rgb(interiour_color)]
+                [FloatObject(n) for n in hex_to_rgb(interior_color)]
             )
 
 

--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -260,7 +260,7 @@ class Ellipse(MarkupAnnotation):
         *,
         interiour_color: Optional[str] = None,
         **kwargs: Any,
-    ):        
+    ):
         if "interiour_color" in kwargs:
             deprecate_with_replacement("interiour_color", "interior_color", "6.0.0")
             interior_color = kwargs["interiour_color"]

--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -264,6 +264,7 @@ class Ellipse(MarkupAnnotation):
         if "interiour_color" in kwargs:
             deprecate_with_replacement("interiour_color", "interior_color", "6.0.0")
             interior_color = kwargs["interiour_color"]
+            del kwargs["interiour_color"]
         super().__init__(**kwargs)
 
         self.update(

--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -2,6 +2,7 @@ import sys
 from abc import ABC
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
+from .._utils import deprecate_with_replacement
 from ..constants import AnnotationFlag
 from ..generic import ArrayObject, DictionaryObject
 from ..generic._base import (
@@ -259,8 +260,12 @@ class Ellipse(MarkupAnnotation):
         *,
         interiour_color: Optional[str] = None,
         **kwargs: Any,
-    ):
+    ):        
+        if "interiour_color" in kwargs:
+            deprecate_with_replacement("interiour_color", "interior_color", "6.0.0")
+            interior_color = kwargs["interiour_color"]
         super().__init__(**kwargs)
+
         self.update(
             {
                 NameObject("/Type"): NameObject("/Annot"),
@@ -269,9 +274,9 @@ class Ellipse(MarkupAnnotation):
             }
         )
 
-        if interiour_color:
+        if interior_color:
             self[NameObject("/IC")] = ArrayObject(
-                [FloatObject(n) for n in hex_to_rgb(interiour_color)]
+                [FloatObject(n) for n in hex_to_rgb(interior_color)]
             )
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3,11 +3,51 @@
 from pathlib import Path
 
 from pypdf import PdfReader, PdfWriter
-from pypdf.annotations import FreeText, Text
+from pypdf.annotations import Ellipse, FreeText, Rectangle, Text
 
 TESTS_ROOT = Path(__file__).parent.resolve()
 PROJECT_ROOT = TESTS_ROOT.parent
 RESOURCE_ROOT = PROJECT_ROOT / "resources"
+
+
+def test_ellipse_annotation(pdf_file_path):
+    # Arrange
+    pdf_path = RESOURCE_ROOT / "crazyones.pdf"
+    reader = PdfReader(pdf_path)
+    page = reader.pages[0]
+    writer = PdfWriter()
+    writer.add_page(page)
+
+    # Act
+    ellipse_annotation = Ellipse(
+        rect=(50, 550, 500, 650),
+        interior_color="ff0000",
+    )
+    writer.add_annotation(0, ellipse_annotation)
+
+    # Assert: You need to inspect the file manually
+    with open(pdf_file_path, "wb") as fp:
+        writer.write(fp)
+
+
+def test_rectangle_annotation(pdf_file_path):
+    # Arrange
+    pdf_path = RESOURCE_ROOT / "crazyones.pdf"
+    reader = PdfReader(pdf_path)
+    page = reader.pages[0]
+    writer = PdfWriter()
+    writer.add_page(page)
+
+    # Act
+    rectangle_annotation = Rectangle(
+        rect=(50, 550, 500, 650),
+        interior_color="ff0000",
+    )
+    writer.add_annotation(0, rectangle_annotation)
+
+    # Assert: You need to inspect the file manually
+    with open(pdf_file_path, "wb") as fp:
+        writer.write(fp)
 
 
 def test_text_annotation(pdf_file_path):

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -858,12 +858,6 @@ def test_annotation_builder_square(pdf_file_path):
 
     with pytest.warns(DeprecationWarning):
         square_annotation = AnnotationBuilder.rectangle(
-            rect=(50, 50, 100, 100), interior_color="ff0000"
-        )
-    writer.add_annotation(0, square_annotation)
-
-    with pytest.warns(DeprecationWarning):
-        square_annotation = AnnotationBuilder.rectangle(
             rect=(40, 400, 150, 450),
         )
     writer.add_annotation(0, square_annotation)
@@ -951,12 +945,6 @@ def test_annotation_builder_circle(pdf_file_path):
     with pytest.warns(DeprecationWarning):
         circle_annotation = AnnotationBuilder.ellipse(
             rect=(50, 550, 200, 650), interiour_color="ff0000"
-        )
-    writer.add_annotation(0, circle_annotation)
-
-    with pytest.warns(DeprecationWarning):
-        circle_annotation = AnnotationBuilder.ellipse(
-            rect=(50, 50, 100, 100), interior_color="ff0000"
         )
     writer.add_annotation(0, circle_annotation)
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -858,6 +858,12 @@ def test_annotation_builder_square(pdf_file_path):
 
     with pytest.warns(DeprecationWarning):
         square_annotation = AnnotationBuilder.rectangle(
+            rect=(50, 50, 100, 100), interior_color="ff0000"
+        )
+    writer.add_annotation(0, square_annotation)
+
+    with pytest.warns(DeprecationWarning):
+        square_annotation = AnnotationBuilder.rectangle(
             rect=(40, 400, 150, 450),
         )
     writer.add_annotation(0, square_annotation)
@@ -945,6 +951,12 @@ def test_annotation_builder_circle(pdf_file_path):
     with pytest.warns(DeprecationWarning):
         circle_annotation = AnnotationBuilder.ellipse(
             rect=(50, 550, 200, 650), interiour_color="ff0000"
+        )
+    writer.add_annotation(0, circle_annotation)
+
+    with pytest.warns(DeprecationWarning):
+        circle_annotation = AnnotationBuilder.ellipse(
+            rect=(50, 50, 100, 100), interior_color="ff0000"
         )
     writer.add_annotation(0, circle_annotation)
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2706](https://togithub.com/py-pdf/pypdf/pull/2706).



The original branch is fork-2706-j-t-1/deprecation