### PR TITLE
DOC: Remove references to tox from docs

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -19,26 +19,6 @@ You can even disable all of them: `pytest -m "not enable_socket" -m "not samples
 
 Please note that this reduces test coverage. The CI will always test all files.
 
-## Creating a Coverage Report
-
-If you want to get a coverage report that considers the Python version specific
-code, you can run [`tox`](https://tox.wiki/en/latest/).
-
-As a prerequisite, we recommend using [`pyenv`](https://github.com/pyenv/pyenv)
-so that you can install the different Python versions:
-
-```
-pyenv install pypy3.8-7.3.7
-pyenv install 3.7.15
-pyenv install 3.8.12
-pyenv install 3.9.10
-pyenv install 3.10.2
-```
-
-Then you can execute `tox` which will create a coverage report in HTML form
-in the end. The execution takes about 30 minutes.
-
-
 ## Docstrings in Unit tests
 
 The first line of a docstring in a unit test should be written in a way that


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2720](https://togithub.com/py-pdf/pypdf/pull/2720).



The original branch is upstream/tox-docs