### PR TITLE
ENH: accepts ETen-B5 and UniCNS-UTF16 encodings

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -121,9 +121,14 @@ _predefined_cmap: Dict[str, str] = {
     "/GBK-EUC-V": "gbk",  # TBC
     "/GBK2K-H": "gb18030",
     "/GBK2K-V": "gb18030",
+    "/ETen-B5-H": "cp950",
+    "/ETen-B5-V": "cp950",
+    "/ETenms-B5-H": "cp950",
+    "/ETenms-B5-V": "cp950",
+    "/UniCNS-UTF16-H": "utf-16-be",  # TBC
+    "/UniCNS-UTF16-V": "utf-16-be",  # TBC
     # UCS2 in code
 }
-
 
 # manually extracted from http://mirrors.ctan.org/fonts/adobe/afm/Adobe-Core35_AFMs-229.tar.gz
 _default_fonts_space_width: Dict[str, int] = {

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -113,20 +113,20 @@ unknown_char_map: Tuple[str, float, Union[str, Dict[int, str]], Dict[Any, Any]] 
 _predefined_cmap: Dict[str, str] = {
     "/Identity-H": "utf-16-be",
     "/Identity-V": "utf-16-be",
-    "/GB-EUC-H": "gbk",  # TBC
-    "/GB-EUC-V": "gbk",  # TBC
-    "/GBpc-EUC-H": "gb2312",  # TBC
-    "/GBpc-EUC-V": "gb2312",  # TBC
-    "/GBK-EUC-H": "gbk",  # TBC
-    "/GBK-EUC-V": "gbk",  # TBC
+    "/GB-EUC-H": "gbk",
+    "/GB-EUC-V": "gbk",
+    "/GBpc-EUC-H": "gb2312",
+    "/GBpc-EUC-V": "gb2312",
+    "/GBK-EUC-H": "gbk",
+    "/GBK-EUC-V": "gbk",
     "/GBK2K-H": "gb18030",
     "/GBK2K-V": "gb18030",
     "/ETen-B5-H": "cp950",
     "/ETen-B5-V": "cp950",
     "/ETenms-B5-H": "cp950",
     "/ETenms-B5-V": "cp950",
-    "/UniCNS-UTF16-H": "utf-16-be",  # TBC
-    "/UniCNS-UTF16-V": "utf-16-be",  # TBC
+    "/UniCNS-UTF16-H": "utf-16-be",
+    "/UniCNS-UTF16-V": "utf-16-be",
     # UCS2 in code
 }
 

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -199,3 +199,10 @@ def test_ignoring_non_put_entries():
     """Issue #2290"""
     reader = PdfReader(BytesIO(get_data_from_url(name="iss2290.pdf")))
     reader.pages[0].extract_text()
+
+
+@pytest.mark.enable_socket()
+def test_eten_b5():
+    """Issue #2356"""
+    reader = PdfReader(BytesIO(get_data_from_url(name="iss2290.pdf")))
+    reader.pages[0].extract_text().startswith("1/7 \n富邦新終身壽險")


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2721](https://togithub.com/py-pdf/pypdf/pull/2721).



The original branch is fork-2721-pubpub-zz/iss2356