### PR TITLE
MAINT: Add deprecate_with_replacement to StreamObject.initializeFromD…

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -903,9 +903,10 @@ class StreamObject(DictionaryObject):
         stream.write(b"\nendstream")
 
     @staticmethod
-    def initializeFromDictionary(  # TODO: mention when to deprecate
+    def initializeFromDictionary(
         data: Dict[str, Any]
-    ) -> Union["EncodedStreamObject", "DecodedStreamObject"]:  # deprecated
+    ) -> Union["EncodedStreamObject", "DecodedStreamObject"]:
+        deprecate_with_replacement("initializeFromDictionary", "initialize_from_dictionary", "5.0.0")
         return StreamObject.initialize_from_dictionary(data)
 
     @staticmethod

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -906,7 +906,9 @@ class StreamObject(DictionaryObject):
     def initializeFromDictionary(
         data: Dict[str, Any]
     ) -> Union["EncodedStreamObject", "DecodedStreamObject"]:
-        deprecate_with_replacement("initializeFromDictionary", "initialize_from_dictionary", "5.0.0")  # pragma: no cover
+        deprecate_with_replacement(
+            "initializeFromDictionary", "initialize_from_dictionary", "5.0.0"
+        )  # pragma: no cover
         return StreamObject.initialize_from_dictionary(data)
 
     @staticmethod

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -909,7 +909,7 @@ class StreamObject(DictionaryObject):
         deprecate_with_replacement(
             "initializeFromDictionary", "initialize_from_dictionary", "5.0.0"
         )  # pragma: no cover
-        return StreamObject.initialize_from_dictionary(data)
+        return StreamObject.initialize_from_dictionary(data)  # pragma: no cover
 
     @staticmethod
     def initialize_from_dictionary(

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -906,7 +906,7 @@ class StreamObject(DictionaryObject):
     def initializeFromDictionary(
         data: Dict[str, Any]
     ) -> Union["EncodedStreamObject", "DecodedStreamObject"]:
-        deprecate_with_replacement("initializeFromDictionary", "initialize_from_dictionary", "5.0.0")
+        deprecate_with_replacement("initializeFromDictionary", "initialize_from_dictionary", "5.0.0")  # pragma: no cover
         return StreamObject.initialize_from_dictionary(data)
 
     @staticmethod


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2728](https://togithub.com/py-pdf/pypdf/pull/2728).



The original branch is fork-2728-j-t-1/deprecate