### PR TITLE
ROB: cope with fields with upside down box/rectangle

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -462,7 +462,9 @@ class PdfWriter(PdfDocCommon):
 
     def create_viewer_preferences(self) -> ViewerPreferences:
         o = ViewerPreferences()
-        self._root_object[NameObject(CatalogDictionary.VIEWER_PREFERENCES)] = self._add_object(o)
+        self._root_object[
+            NameObject(CatalogDictionary.VIEWER_PREFERENCES)
+        ] = self._add_object(o)
         return o
 
     def add_page(
@@ -778,7 +780,7 @@ class PdfWriter(PdfDocCommon):
     ) -> None:
         # Calculate rectangle dimensions
         _rct = cast(RectangleObject, anno[AA.Rect])
-        rct = RectangleObject((0, 0, _rct[2] - _rct[0], _rct[3] - _rct[1]))
+        rct = RectangleObject((0, 0, abs(_rct[2] - _rct[0]), abs(_rct[3] - _rct[1])))
 
         # Extract font information
         da = anno.get_inherited(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2269,3 +2269,20 @@ def test_no_ressource_for_14_std_fonts(caplog):
                 p, {a["/T"]: "Brooks"}, auto_regenerate=False
             )
     assert "Font dictionary for /Helvetica not found." in caplog.text
+
+
+@pytest.mark.enable_socket()
+def test_field_box_upside_down():
+    """Cf #2724"""
+    url = "https://github.com/user-attachments/files/15996356/FRA.F.6180.55.pdf"
+    name = "iss2724.pdf"
+    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer.update_page_form_field_values(None, {"FreightTrainMiles": "0"})
+    assert writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data() == (
+        b"q\n/Tx BMC \nq\n1 1 105.29520000000001 10.835000000000036 re\n"
+        b"W\nBT\n/Arial 8.0 Tf 0 g\n2 2.8350000000000364 Td\n(0) Tj\nET\n"
+        b"Q\nEMC\nQ\n"
+    )
+    box = writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"]["/BBox"]
+    assert box[2] > 0
+    assert box[3] > 0


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2729](https://togithub.com/py-pdf/pypdf/pull/2729).



The original branch is fork-2729-pubpub-zz/iss2724