### PR TITLE
STY: Use endswith in logical equals

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -100,7 +100,7 @@ def parse_iso8824_date(text: Optional[str]) -> Optional[datetime]:
         except ValueError:
             continue
         else:
-            if text[-5:] == "+0000":
+            if text.endswith("+0000"):
                 d = d.replace(tzinfo=timezone.utc)
             return d
     raise ValueError(f"Can not convert date: {orgtext}")


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2732](https://togithub.com/py-pdf/pypdf/pull/2732).



The original branch is fork-2732-j-t-1/endswith