### PR TITLE
MAINT: Deal with cryptography>=43 moving ARC4

### DIFF
--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -29,7 +29,13 @@ import secrets
 
 from cryptography import __version__
 from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
+
+try:
+    # 43.0.0 - https://cryptography.io/en/latest/changelog/#v43-0-0
+    from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives.ciphers.base import Cipher
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [py-pdf/pypdf#2765](https://togithub.com/py-pdf/pypdf/pull/2765).



The original branch is upstream/cryptography-upgrade